### PR TITLE
fix permissions and duplicate start calls

### DIFF
--- a/start-photon.sh
+++ b/start-photon.sh
@@ -105,9 +105,9 @@ verify_structure() {
     # Ensure proper permissions
     log_debug "Setting permissions for elasticsearch directory"
     log_debug "Pre-permission state: $(stat -c '%a %U:%G %n' $dir/photon_data/elasticsearch 2>/dev/null || echo 'missing')"
-    chown -R 1000:1000 "$dir/photon_data/elasticsearch" 2>/dev/null || true
-    chmod -R 755 "$dir/photon_data/elasticsearch" 2>/dev/null || true
-    log_debug "Post-permission state: $(stat -c '%a %U:%G %n' $dir/photon_data/elasticsearch 2>/dev/null || echo 'missing')"
+    # chown -R 1000:1000 "$dir/photon_data/elasticsearch" 2>/dev/null || true
+    # chmod -R 755 "$dir/photon_data/elasticsearch" 2>/dev/null || true
+    # log_debug "Post-permission state: $(stat -c '%a %U:%G %n' $dir/photon_data/elasticsearch 2>/dev/null || echo 'missing')"
     
     return 0
 }


### PR DESCRIPTION
feat: Add extensive debug logging for file operations
fix: remove explicit permission changes
refactor: remove redundant comments for improved readability
fix: ensure Photon service is not started if already running
feat: add logging for Photon service start and PID management
fix: handle failure of forced update and service start
feat: restart Photon service after scheduled index update