### PR TITLE
feat: adopt existing logic to the OpenSearch version of photon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /photon
 
 RUN mkdir -p /photon/photon_data
 
-ADD https://github.com/komoot/photon/releases/download/${PHOTON_VERSION}/photon-${PHOTON_VERSION}.jar /photon/photon.jar
+ADD https://github.com/komoot/photon/releases/download/${PHOTON_VERSION}/photon-opensearch-${PHOTON_VERSION}.jar /photon/photon.jar
 
 COPY start-photon.sh ./start-photon.sh
 COPY src/ ./src/

--- a/src/config.sh
+++ b/src/config.sh
@@ -4,7 +4,7 @@
 PHOTON_DIR="/photon"
 PHOTON_DATA_DIR="${PHOTON_DIR}/photon_data"
 PHOTON_JAR="${PHOTON_DIR}/photon.jar"
-ES_DATA_DIR="${PHOTON_DATA_DIR}/elasticsearch"
+ES_DATA_DIR="${PHOTON_DATA_DIR}/node_1"
 INDEX_DIR="${ES_DATA_DIR}"
 TEMP_DIR="${PHOTON_DATA_DIR}/temp"
 PID_FILE="${PHOTON_DIR}/photon.pid"
@@ -13,7 +13,7 @@ PID_FILE="${PHOTON_DIR}/photon.pid"
 UPDATE_STRATEGY=${UPDATE_STRATEGY:-SEQUENTIAL}
 UPDATE_INTERVAL=${UPDATE_INTERVAL:-24h}
 LOG_LEVEL=${LOG_LEVEL:-INFO}
-BASE_URL=${BASE_URL:-https://download1.graphhopper.com/public}
+BASE_URL=${BASE_URL:-https://download1.graphhopper.com/public/experimental}
 FORCE_UPDATE=${FORCE_UPDATE:-FALSE}
 SKIP_MD5_CHECK=${SKIP_MD5_CHECK:-FALSE}
 


### PR DESCRIPTION
## Summary by Sourcery

Adapt Photon setup and Docker configuration to use the OpenSearch distribution instead of Elasticsearch by updating directory names, log messages, permissions, and download URLs.

Enhancements:
- Replace Elasticsearch directory paths and names with OpenSearch (node_1) in scripts and configuration.
- Update log messages and permission comments to refer to OpenSearch instead of Elasticsearch.
- Change default BASE_URL to the experimental path for OpenSearch index downloads.
- Modify Dockerfile to download the photon-opensearch JAR instead of the Elasticsearch-based build.