### PR TITLE
update paths, remove ES index dir after updates

### DIFF
--- a/src/config.sh
+++ b/src/config.sh
@@ -4,8 +4,9 @@
 PHOTON_DIR="/photon"
 PHOTON_DATA_DIR="${PHOTON_DIR}/photon_data"
 PHOTON_JAR="${PHOTON_DIR}/photon.jar"
-ES_DATA_DIR="${PHOTON_DATA_DIR}/node_1"
-INDEX_DIR="${ES_DATA_DIR}"
+OS_DATA_DIR="${PHOTON_DATA_DIR}/node_1"
+INDEX_DIR="${OS_DATA_DIR}"
+ES_DATA_DIR="${PHOTON_DATA_DIR}/elasticsearch"
 TEMP_DIR="${PHOTON_DATA_DIR}/temp"
 PID_FILE="${PHOTON_DIR}/photon.pid"
 

--- a/start-photon.sh
+++ b/start-photon.sh
@@ -320,6 +320,17 @@ cleanup_temp() {
     log_info "Final photon_data directory structure:\n$(tree -L 2 $PHOTON_DATA_DIR 2>/dev/null || echo '<empty>')"
 }
 
+cleanup_stale_es() {
+    # Remove old elasticsearch index 
+    if [ -d "$ES_DATA_DIR" ]; then
+        log_info "Removing old elasticsearch directory at $ES_DATA_DIR"
+        log_debug "Executing: rm -rf $ES_DATA_DIR"
+        if ! rm -rf "$ES_DATA_DIR"; then
+            log_error "Failed to remove old elasticsearch index"
+        fi
+    fi
+}
+
 # Prepare download URL based on country code or custom base URL
 prepare_download_url() {
     # Ensure BASE_URL doesn't have trailing slash
@@ -470,8 +481,15 @@ parallel_update() {
 
     # Clean up
     log_debug "Removing old index backup"
+
+
     rm -rf "$INDEX_DIR.old" 2>/dev/null || true
+
+
+    cleanup_stale_es
+
     log_info "Parallel update completed successfully"
+
     cleanup_temp
     return 0
 }
@@ -497,6 +515,8 @@ sequential_update() {
             return 1
         fi
     fi
+
+    cleanup_stale_es
     
     log_info "Downloading new index"
     if ! download_index; then


### PR DESCRIPTION
Restructure data directory paths and ensure old Elasticsearch data is removed during index updates

Enhancements:
- Separate node index directory and Elasticsearch data directory in configuration
- Update INDEX_DIR to use the node index path and redefine ES_DATA_DIR to a dedicated Elasticsearch directory
- Add cleanup steps in parallel and sequential update routines to remove stale Elasticsearch data before rebuilding the index

closes #66

## Summary by Sourcery

Restructure data directory paths and purge stale Elasticsearch data before index rebuilding

New Features:
- Introduce cleanup_stale_es function to remove old Elasticsearch data before updates

Enhancements:
- Separate node index directory and Elasticsearch data directory in configuration
- Invoke cleanup_stale_es in both parallel and sequential update routines to remove stale ES data before rebuilding the index