### PR TITLE
feat: create force_update function

### DIFF
--- a/start-photon.sh
+++ b/start-photon.sh
@@ -563,6 +563,21 @@ update_index() {
     esac
 }
 
+force_update() {
+    case "$UPDATE_STRATEGY" in
+        PARALLEL)
+            parallel_update
+            ;;
+        SEQUENTIAL)
+            sequential_update
+            ;;
+        *)
+            log_info "Defaulting to sequential update for forced updates"
+            sequential_update
+            ;;
+    esac
+}
+
 start_photon() {
     # Check if already running
     if [ -f /photon/photon.pid ]; then
@@ -639,7 +654,7 @@ main() {
     # Only run FORCE_UPDATE once during container startup
     if [ "${FORCE_UPDATE}" = "TRUE" ]; then
         log_info "Performing forced update on startup"
-        if ! update_index; then
+        if ! force_update; then
             log_error "Forced update failed"
             exit 1
         fi


### PR DESCRIPTION
adds force update function to allow triggering a manual update, respecting update strategy with fallback to sequential

## Summary by Sourcery

Introduce a force_update function that chooses the parallel or sequential update method based on UPDATE_STRATEGY (falling back to sequential) and use it for startup forced updates.

New Features:
- Add force_update shell function to trigger manual updates according to the configured update strategy
- Default to sequential update when an unknown strategy is specified
- Invoke force_update instead of update_index for forced updates at container startup