### PR TITLE
add rsync to r2

### DIFF
--- a/.github/workflows/index_sync.yml
+++ b/.github/workflows/index_sync.yml
@@ -1,0 +1,45 @@
+name: Sync GraphHopper Dumps to R2
+
+on:
+    schedule:
+        - cron: "5 4 * * *" # daily at 4:05
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}
+    cancel-in-progress: true
+
+jobs:
+    sync:
+        runs-on: ubuntu-latest
+
+        container:
+            image: rclone/rclone:master
+
+        steps:
+            - name: Configure rclone
+              shell: bash
+              run: |
+                  mkdir -p ~/.config/rclone
+                  cat > ~/.config/rclone/rclone.conf << EOF
+                  [r2]
+                  type = s3
+                  provider = Cloudflare
+                  endpoint = https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+                  access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+                  secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+                  no_check_bucket = true
+                  EOF
+
+            - name: Sync latest photon files
+              shell: bash
+              run: |
+                  echo "Syncing the latest database file..."
+                  rclone copyurl --checksum --progress --auto-filename \
+                    "https://download1.graphhopper.com/public/experimental/photon-db-latest.tar.bz2" \
+                    r2:photon-os/public/experimental/
+
+                  echo "Syncing the latest checksum file..."
+                  rclone copyurl --checksum --progress --auto-filename \
+                    "https://download1.graphhopper.com/public/experimental/photon-db-latest.tar.bz2.md5" \
+                    r2:photon-os/public/experimental/


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the synchronization of GraphHopper dump files to R2 storage. The workflow is scheduled to run daily and can also be triggered manually.

### Addition of a new workflow for file synchronization:

* [`.github/workflows/index_sync.yml`](diffhunk://#diff-33cc7ecfd4e00fd858f4cb0304a46b5b59e0b54807535d42e5c82f37f988324eR1-R39): Created a new workflow named "Sync GraphHopper Dumps to R2," which runs daily at 4:05 AM and supports manual triggering. It uses the `rclone` container to configure storage credentials and synchronize files from GraphHopper to R2 storage.

## Summary by Sourcery

Add a GitHub Actions workflow to automate daily and on-demand synchronization of GraphHopper dump and checksum files to Cloudflare R2 storage using rclone.

New Features:
- Automate GraphHopper dumps synchronization to Cloudflare R2 via GitHub Actions

Enhancements:
- Configure rclone in the workflow to copy the latest GraphHopper dump and checksum files to R2

CI:
- Schedule the sync workflow to run daily at 4:05 AM and enable manual dispatch