### PR TITLE
Reload resume position when retrying download

### DIFF
--- a/src/downloader.py
+++ b/src/downloader.py
@@ -490,10 +490,10 @@ def _perform_download(url, destination, resume_byte_pos, mode, start_time):
 
 
 def download_file(url, destination, max_retries=3):
-    resume_byte_pos, mode = _prepare_download(url, destination)
     start_time = time.time()
 
     for attempt in range(max_retries):
+        resume_byte_pos, mode = _prepare_download(url, destination)
         try:
             return _perform_download(url, destination, resume_byte_pos, mode, start_time)
 


### PR DESCRIPTION
The current code in `download_file` loads the resume position only once before three repeated attempts.  This means that it will never resume anything, because the entire temporary directory is cleared prior to attempting to download any file.

By instead reloading before each attempt, downloading can advance even when connections to the file server get killed after multiple hours.

It might additionally be useful to reset the attempt counter whenever the `resume_byte_pos` advances, or adjust the rest of this file to not delete in-progress downloads