### PR TITLE
fix: file size mismatch when download interrupted

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -121,9 +121,9 @@ jobs:
                   IS_PRERELEASE="${{ env.IS_PRERELEASE }}"
                   SHOULD_PUSH="${{ env.SHOULD_PUSH }}"
 
-                  REPO_NAME="${{ github.repository }}"
-                  DOCKERHUB_REPO="${REPO_NAME,,}"
-                  GHCR_REPO="ghcr.io/${REPO_NAME,,}"
+                  # TODO change 
+                  DOCKERHUB_REPO="rtuszik/photon-docker"
+                  GHCR_REPO="ghcr.io/rtuszik/photon-docker"
 
                   TAGS="$DOCKERHUB_REPO:$CONTAINER_VERSION,$GHCR_REPO:$CONTAINER_VERSION"
 
@@ -137,12 +137,12 @@ jobs:
                         MAJOR="${BASH_REMATCH[1]}"
                         MINOR="${BASH_REMATCH[2]}"
                         PATCH="${BASH_REMATCH[3]}"
-
+                        
                         TAGS="$TAGS,$DOCKERHUB_REPO:$MAJOR,$GHCR_REPO:$MAJOR"
                         TAGS="$TAGS,$DOCKERHUB_REPO:$MAJOR.$MINOR,$GHCR_REPO:$MAJOR.$MINOR"
                         TAGS="$TAGS,$DOCKERHUB_REPO:$MAJOR.$MINOR.$PATCH,$GHCR_REPO:$MAJOR.$MINOR.$PATCH"
                         TAGS="$TAGS,$DOCKERHUB_REPO:latest,$GHCR_REPO:latest"
-
+                        
                         echo "Generated semver tags for version $MAJOR.$MINOR.$PATCH"
                       else
                         echo "Version doesn't match semver pattern, skipping semver tags"


### PR DESCRIPTION
#### Problem

When downloading large files (e.g., a 117GB photon-db), connection failures cause the entire download to restart from scratch instead of resuming, because the download state is saved only every 1MB.

#### Why it happens:

When the connection drops mid-download, the file contains more data than the last saved state, and on retry, the exact size check fails.

1. Download state is saved every 1MB (`save_interval = 1024 * 1024`)
2. When connection drops mid-download, the file contains more data than the last saved state
3. On retry, the exact size check fails
4. Script logs "File size mismatch, starting fresh download" and deletes state
5. Download restarts from 0 bytes instead of resuming

#### Fix

This fix ensures that progress is saved even if data written between periodic saves (every 1MB), preventing loss of up to 1MB of progress.

Additionally, increases connection timeout (30s) and read timeout (60s), and adds a backoff timeout to make downloads more reliable on slow or unstable networks.

#### Test

I built a new container and ran tests in my slowest setup.
After a network interruption, the Python script continued downloading the file:

```
2025-10-30 22:09:53,250 - root - INFO - Download progress: 6.8% (7.93GB / 116.98GB) - 47.3 Mbps - ETA: 5h 30m
2025-10-30 22:10:03,250 - root - INFO - Download progress: 6.8% (7.98GB / 116.98GB) - 48.2 Mbps - ETA: 5h 23m
2025-10-30 22:10:13,251 - root - INFO - Download progress: 6.9% (8.04GB / 116.98GB) - 47.5 Mbps - ETA: 5h 28m
2025-10-30 22:11:16,951 - root - WARNING - Download attempt 1 failed: HTTPSConnectionPool(host='r2.koalasec.org', port=443): Read timed out.
2025-10-30 22:11:16,954 - root - INFO - Waiting 1s before retry...
2025-10-30 22:11:17,956 - root - INFO - Retrying download (attempt 2/3)...
2025-10-30 22:11:17,960 - root - INFO - Resuming download: file size 8654962688 bytes (saved state: 8654962688 bytes)
2025-10-30 22:11:17,961 - root - INFO - Resuming download from byte 8654962688
2025-10-30 22:11:18,851 - root - INFO - Starting download of 116.98GB to photon-db-latest.tar.bz2
2025-10-30 22:11:28,854 - root - INFO - Download progress: 6.9% (8.11GB / 116.98GB) - 38.5 Mbps - ETA: 6h 44m
2025-10-30 22:11:38,856 - root - INFO - Download progress: 7.0% (8.16GB / 116.98GB) - 47.0 Mbps - ETA: 5h 31m
2025-10-30 22:11:48,859 - root - INFO - Download progress: 7.0% (8.22GB / 116.98GB) - 47.2 Mbps - ETA: 5h 29m
```

It may still be worth increasing the read timeout further (e.g., from `timeout=(30, 60)` to `timeout=(30, 300)`), but at least the download now continues instead of restarting from the beginning.

Fixes #169 