### PR TITLE
fix: check if update is due based on UPDATE_INTERVAL daily

### DIFF
--- a/src/process_manager.py
+++ b/src/process_manager.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import datetime
 import os
 import shlex
 import signal
@@ -10,7 +11,6 @@ from enum import Enum
 
 import psutil
 import requests
-import schedule
 from requests.exceptions import RequestException
 
 from src.check_remote import compare_mtime
@@ -252,35 +252,52 @@ class PhotonManager:
 
         self.state = AppState.RUNNING
 
+    def _parse_interval(self, interval: str) -> datetime.timedelta:
+        interval = interval.lower()
+        value = int(interval[:-1])
+        unit = interval[-1]
+        if unit == "d":
+            return datetime.timedelta(days=value)
+        if unit == "h":
+            return datetime.timedelta(hours=value)
+        if unit == "m":
+            return datetime.timedelta(minutes=value)
+        logger.warning(f"Invalid UPDATE_INTERVAL format: {interval}, defaulting to 1 day")
+        return datetime.timedelta(days=1)
+
+    def _is_update_due(self) -> bool:
+        marker_file = os.path.join(config.DATA_DIR, ".photon-index-updated")
+        if not os.path.exists(marker_file):
+            logger.info("No marker file found, update is due")
+            return True
+
+        marker_time = datetime.datetime.fromtimestamp(os.path.getmtime(marker_file))
+        now = datetime.datetime.now()
+        elapsed = now - marker_time
+        interval = self._parse_interval(config.UPDATE_INTERVAL)
+
+        if elapsed < interval:
+            remaining = interval - elapsed
+            logger.info(f"Last update was {elapsed} ago, next check in {remaining}, skipping")
+            return False
+
+        logger.info(f"Last update was {elapsed} ago (interval: {interval}), update due")
+        return True
+
     def schedule_updates(self):
         if config.UPDATE_STRATEGY == "DISABLED":
             logger.info("Updates disabled, not scheduling")
             return
 
-        interval = config.UPDATE_INTERVAL.lower()
+        logger.info(f"Scheduling daily update checks (update interval: {config.UPDATE_INTERVAL})")
 
-        if interval.endswith("d"):
-            days = int(interval[:-1])
-            schedule.every(days).days.do(self.run_update)
-            logger.info(f"Scheduling updates every {days} days")
-        elif interval.endswith("h"):
-            hours = int(interval[:-1])
-            schedule.every(hours).hours.do(self.run_update)
-            logger.info(f"Scheduling updates every {hours} hours")
-        elif interval.endswith("m"):
-            minutes = int(interval[:-1])
-            schedule.every(minutes).minutes.do(self.run_update)
-            logger.info(f"Scheduling updates every {minutes} minutes")
-        else:
-            logger.warning(f"Invalid UPDATE_INTERVAL format: {interval}, defaulting to daily")
-            schedule.every().day.do(self.run_update)
-
-        def scheduler_loop():
+        def update_loop():
             while not self.should_exit:
-                schedule.run_pending()
-                time.sleep(1)
+                if self._is_update_due():
+                    self.run_update()
+                time.sleep(86400)
 
-        thread = threading.Thread(target=scheduler_loop, daemon=True)
+        thread = threading.Thread(target=update_loop, daemon=True)
         thread.start()
 
     def monitor_photon(self):


### PR DESCRIPTION
Originally updates would only be checked if they need to happen based on the duration of `UPDATE_INTERVAL`.  This means that if the container is restarted, it resets the timer.  

This change compares the timestamp on `DATA_DIR/.photon-index-updated` to the `UPDATE_INTERVAL` on a daily basis.  

I believe this was the originally intended functionality, as by default it means the container needs to be running for 30 days before an update is even attempted...instead of doing updates every `UPDATE_INTERVAL`.