### PR TITLE
support non-root execution in entrypoint.sh

### DIFF
--- a/.github/workflows/full-test-jsonl.yml
+++ b/.github/workflows/full-test-jsonl.yml
@@ -14,6 +14,7 @@ on:
             - "pyproject.toml"
             - "uv.lock"
             - ".github/**"
+            - "entrypoint.sh"
 
 permissions:
     contents: read

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -14,6 +14,7 @@ on:
             - "pyproject.toml"
             - "uv.lock"
             - ".github/**"
+            - "entrypoint.sh"
 
 permissions:
     contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,8 @@ on:
             - "uv.lock"
             - ".python-version"
             - ".github/**"
+            - "entrypoint.sh"
+
     workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,6 +10,7 @@ on:
             - "uv.lock"
             - "Dockerfile"
             - ".github/**"
+            - "entrypoint.sh"
 
 permissions:
     contents: write

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,23 +1,28 @@
 #!/bin/sh
 
-PUID=${PUID:-9011}
-PGID=${PGID:-9011}
+RUNNING_AS_ROOT=false
 
-CURRENT_UID=$(id -u photon 2>/dev/null || echo "0")
-CURRENT_GID=$(id -g photon 2>/dev/null || echo "0")
+if [ "$(id -u)" -eq 0 ]; then
+    RUNNING_AS_ROOT=true
+    PUID=${PUID:-9011}
+    PGID=${PGID:-9011}
 
-if [ "$CURRENT_GID" != "$PGID" ]; then
-    echo "Updating photon group GID from $CURRENT_GID to $PGID"
-    groupmod -o -g "$PGID" photon
-    echo "Updating ownership of files from GID $CURRENT_GID to $PGID"
-    find / -group "$CURRENT_GID" -exec chgrp -h "$PGID" {} \; 2>/dev/null
-fi
+    CURRENT_UID=$(id -u photon 2>/dev/null || echo "0")
+    CURRENT_GID=$(id -g photon 2>/dev/null || echo "0")
 
-if [ "$CURRENT_UID" != "$PUID" ]; then
-    echo "Updating photon user UID from $CURRENT_UID to $PUID"
-    usermod -o -u "$PUID" photon
-    echo "Updating ownership of files from UID $CURRENT_UID to $PUID"
-    find / -user "$CURRENT_UID" -exec chown -h "$PUID" {} \; 2>/dev/null
+    if [ "$CURRENT_GID" != "$PGID" ]; then
+        echo "Updating photon group GID from $CURRENT_GID to $PGID"
+        groupmod -o -g "$PGID" photon
+        echo "Updating ownership of files from GID $CURRENT_GID to $PGID"
+        find / -group "$CURRENT_GID" -exec chgrp -h "$PGID" {} \; 2>/dev/null
+    fi
+
+    if [ "$CURRENT_UID" != "$PUID" ]; then
+        echo "Updating photon user UID from $CURRENT_UID to $PUID"
+        usermod -o -u "$PUID" photon
+        echo "Updating ownership of files from UID $CURRENT_UID to $PUID"
+        find / -user "$CURRENT_UID" -exec chown -h "$PUID" {} \; 2>/dev/null
+    fi
 fi
 
 if [ -d "/photon/data/photon_data/node_1" ]; then
@@ -33,5 +38,9 @@ elif [ -d "/photon/data/node_1" ]; then
     echo "Migration complete: moved node_1 to /photon/data/photon_data/"
 fi
 
-chown -R photon:photon /photon
-exec gosu photon "$@"
+if [ "$RUNNING_AS_ROOT" = true ]; then
+    chown -R photon:photon /photon
+    exec gosu photon "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
updates the `entrypoint.sh` script to allow running container as non-root without failing at gosu step-down. 

closes #369 